### PR TITLE
fixed comments syntax

### DIFF
--- a/nunjucks.configuration.json
+++ b/nunjucks.configuration.json
@@ -1,9 +1,9 @@
 {
 	"comments": {
 		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
+		//"lineComment": "{#",
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-		"blockComment": [ "/*", "*/" ]
+		"blockComment": [ "{#", "#}" ]
 	},
 	// symbols used as brackets
 	"brackets": [


### PR DESCRIPTION
nunjucks comments syntax is the following : 
```
{# <div> this div is not shown </div> #}
```

Wene you use the shoutcut ```CMD + /``` on OSX the following wrong comment syntax is used:
```
// <div> this div is not shown </div> 
```
