### PR TITLE
add MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 ronnidc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
 	"description": "A Nunjucks syntax definition + snippets",
 	"version": "0.3.1",
 	"publisher": "ronnidc",
+	"author": "ronnidc",
+	"license": "MIT",
 	"icon": "images/vscode-nunjucks-extension-logo.png",
 	"engines": {
 		"vscode": "^1.0.0"


### PR DESCRIPTION
Following my question about licensing (https://github.com/ronnidc/vscode-nunjucks/issues/33) I thought I could be more constructive and help ease the project to formally adopting a license!

This pull request adds an MIT license to the project while maintaining @ronnidc as the author. Given that there are multiple contributors and the source is hosted on GitHub, I assume that not adding a license was an oversight. MIT is a common license for such projects.

